### PR TITLE
8 학교 관리자가 지역 학교명으로 학교 페이지 생성 api 구현 및 e2e 코드 작성

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from './auth/guard/jwt-auth.guard';
+import { SchoolsModule } from './schools/schools.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { JwtAuthGuard } from './auth/guard/jwt-auth.guard';
     }),
     AuthModule,
     UsersModule,
+    SchoolsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/schools/dto/schools.dto.ts
+++ b/src/schools/dto/schools.dto.ts
@@ -1,0 +1,13 @@
+import { IsString } from 'class-validator';
+
+export class CreateSchoolPageDto {
+  id: string;
+
+  admins: string[];
+
+  @IsString()
+  name: string;
+
+  @IsString()
+  region_name: string;
+}

--- a/src/schools/interface/region.interface.ts
+++ b/src/schools/interface/region.interface.ts
@@ -1,0 +1,6 @@
+export interface RegionKey {
+  name: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Region extends RegionKey {}

--- a/src/schools/interface/schools.interface.ts
+++ b/src/schools/interface/schools.interface.ts
@@ -1,0 +1,9 @@
+export interface SchoolKey {
+  id?: string;
+}
+
+export interface School extends SchoolKey {
+  name: string;
+  region_name: string;
+  admins: string[];
+}

--- a/src/schools/schema/region.schema.ts
+++ b/src/schools/schema/region.schema.ts
@@ -1,0 +1,12 @@
+import { Schema, model } from 'dynamoose';
+
+export const RegionSchema = new Schema({
+  // 도 단위
+  name: {
+    type: String,
+    hashKey: true,
+    required: true,
+  },
+});
+
+export const UserModel = model('Regions', RegionSchema);

--- a/src/schools/schema/region.schema.ts
+++ b/src/schools/schema/region.schema.ts
@@ -9,4 +9,4 @@ export const RegionSchema = new Schema({
   },
 });
 
-export const UserModel = model('Regions', RegionSchema);
+export const RegionModel = model('Regions', RegionSchema);

--- a/src/schools/schema/schools.schema.ts
+++ b/src/schools/schema/schools.schema.ts
@@ -24,4 +24,4 @@ export const SchoolSchema = new Schema({
     required: true,
   },
 });
-export const UserModel = model('Schools', SchoolSchema);
+export const SchoolModel = model('Schools', SchoolSchema);

--- a/src/schools/schema/schools.schema.ts
+++ b/src/schools/schema/schools.schema.ts
@@ -1,0 +1,27 @@
+import { Schema, model } from 'dynamoose';
+
+export const SchoolSchema = new Schema({
+  id: {
+    type: String,
+    hashKey: true,
+    required: true,
+  },
+
+  name: {
+    type: String,
+    rangeKey: true,
+    required: true,
+  },
+
+  region_name: {
+    type: String,
+    required: true,
+  },
+
+  admins: {
+    type: Array,
+    schema: [String],
+    required: true,
+  },
+});
+export const UserModel = model('Schools', SchoolSchema);

--- a/src/schools/schools.controller.spec.ts
+++ b/src/schools/schools.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SchoolsController } from './schools.controller';
+
+describe('SchoolsController', () => {
+  let controller: SchoolsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SchoolsController],
+    }).compile();
+
+    controller = module.get<SchoolsController>(SchoolsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/schools/schools.controller.ts
+++ b/src/schools/schools.controller.ts
@@ -1,0 +1,36 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  HttpStatus,
+  Post,
+  Req,
+  Res,
+} from '@nestjs/common';
+import { SchoolsService } from './schools.service';
+import { CreateSchoolPageDto } from './dto/schools.dto';
+import { Request, Response } from 'express';
+
+@Controller('schools')
+export class SchoolsController {
+  constructor(private readonly schoolService: SchoolsService) {}
+
+  @Post()
+  async createSchoolPage(
+    @Req() req: Request,
+    @Body() createSchoolPageDto: CreateSchoolPageDto,
+    @Res() res: Response,
+  ) {
+    const region = await this.schoolService.findRegion(
+      createSchoolPageDto.region_name,
+    );
+
+    if (!region[0]) {
+      throw new BadRequestException('region does not exist');
+    }
+
+    await this.schoolService.createSchoolPage(req.user.id, createSchoolPageDto);
+
+    res.status(HttpStatus.CREATED).json('create school page successfully');
+  }
+}

--- a/src/schools/schools.module.ts
+++ b/src/schools/schools.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { SchoolsService } from './schools.service';
+import { SchoolsController } from './schools.controller';
+import { SchoolSchema } from './schema/schools.schema';
+import { DynamooseModule } from 'nestjs-dynamoose';
+import { RegionSchema } from './schema/region.schema';
+
+@Module({
+  imports: [
+    DynamooseModule.forFeature([
+      {
+        name: 'Schools',
+        schema: SchoolSchema,
+        options: {
+          tableName: 'schools',
+        },
+      },
+      {
+        name: 'Regions',
+        schema: RegionSchema,
+        options: {
+          tableName: 'regions',
+        },
+      },
+    ]),
+  ],
+  providers: [SchoolsService],
+  controllers: [SchoolsController],
+})
+export class SchoolsModule {}

--- a/src/schools/schools.service.spec.ts
+++ b/src/schools/schools.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SchoolsService } from './schools.service';
+
+describe('SchoolsService', () => {
+  let service: SchoolsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SchoolsService],
+    }).compile();
+
+    service = module.get<SchoolsService>(SchoolsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/schools/schools.service.ts
+++ b/src/schools/schools.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel, Model } from 'nestjs-dynamoose';
+import { School, SchoolKey } from './interface/schools.interface';
+import { Region, RegionKey } from './interface/region.interface';
+import { CreateSchoolPageDto } from './dto/schools.dto';
+import { v4 } from 'uuid';
+
+@Injectable()
+export class SchoolsService {
+  constructor(
+    @InjectModel('Schools')
+    private readonly schoolModel: Model<School, SchoolKey>,
+    @InjectModel('Regions')
+    private readonly regionModel: Model<Region, RegionKey>,
+  ) {}
+
+  async findRegion(name: string) {
+    const result = await this.regionModel.query('name').eq(name).exec();
+
+    return result;
+  }
+  async createSchoolPage(
+    user_id: string,
+    createSchoolPageDto: CreateSchoolPageDto,
+  ) {
+    createSchoolPageDto.id = v4();
+    createSchoolPageDto.admins = [user_id];
+
+    await this.schoolModel.create(createSchoolPageDto);
+  }
+}

--- a/src/schools/schools.service.ts
+++ b/src/schools/schools.service.ts
@@ -15,9 +15,14 @@ export class SchoolsService {
   ) {}
 
   async findRegion(name: string) {
-    const result = await this.regionModel.query('name').eq(name).exec();
+    try {
+      const result = await this.regionModel.query('name').eq(name).exec();
 
-    return result;
+      return result;
+    } catch (e) {
+      console.error('쿼리 중 에러가 발생했습니다.');
+      throw e;
+    }
   }
   async createSchoolPage(
     user_id: string,
@@ -25,7 +30,11 @@ export class SchoolsService {
   ) {
     createSchoolPageDto.id = v4();
     createSchoolPageDto.admins = [user_id];
-
-    await this.schoolModel.create(createSchoolPageDto);
+    try {
+      await this.schoolModel.create(createSchoolPageDto);
+    } catch (e) {
+      console.error('쿼리 중 에러가 발생했습니다.');
+      throw e;
+    }
   }
 }

--- a/test/school.e2e-spec.ts
+++ b/test/school.e2e-spec.ts
@@ -1,0 +1,104 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import * as cookieParser from 'cookie-parser';
+import { getModelToken } from 'nestjs-dynamoose';
+
+const mockRegionModel = {
+  query: jest.fn(),
+};
+const mockSchoolModel = {
+  create: jest.fn(),
+};
+describe('school (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+      providers: [
+        { provide: getModelToken('Regions'), useValue: mockRegionModel },
+        { provide: getModelToken('Schools'), useValue: mockSchoolModel },
+      ],
+    })
+      .overrideProvider(getModelToken('Regions'))
+      .useValue(mockRegionModel)
+      .overrideProvider(getModelToken('Schools'))
+      .useValue(mockSchoolModel)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.use(cookieParser());
+    app.enableCors({
+      origin: 'http://localhost:3000',
+      credentials: true,
+    });
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+  const getAdminAuth = async () =>
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'suj970@naver.com', password: '1234' });
+
+  describe('/ (POST)', () => {
+    it('성공적으로 학교 페이지를 생성하는 경우', async () => {
+      jest.spyOn(mockRegionModel, 'query').mockImplementationOnce(() => ({
+        eq: () => ({
+          exec: () => [
+            {
+              name: '서울특별시',
+            },
+          ],
+        }),
+      }));
+
+      const response = await getAdminAuth();
+      const { header } = response;
+
+      return request(app.getHttpServer())
+        .post('/schools')
+        .set('Accept', 'application/json')
+        .set('Cookie', [...header['set-cookie']])
+        .send({
+          name: '성윤고등학교',
+          region_name: '서울특별시',
+        })
+        .expect(201)
+        .expect('"create school page successfully"');
+    });
+    it('지역이 존재하지 않는 경우', async () => {
+      jest.spyOn(mockRegionModel, 'query').mockImplementationOnce(() => ({
+        eq: () => ({
+          exec: () => [],
+        }),
+      }));
+
+      const response = await getAdminAuth();
+      const { header } = response;
+
+      return request(app.getHttpServer())
+        .post('/schools')
+        .set('Accept', 'application/json')
+        .set('Cookie', [...header['set-cookie']])
+        .send({
+          name: '성윤고등학교',
+          region_name: '서울특별시',
+        })
+        .expect(400)
+        .expect({
+          statusCode: 400,
+          message: 'region does not exist',
+          error: 'Bad Request',
+        });
+    });
+  });
+});


### PR DESCRIPTION
## Description
<br>

- 지역은 도 단위까지만 저장하였습니다 데이터는 dynamoDB에 저장해두었습니다. (서울특별시,인천광역시,경기도 등등..)
- 지역 스키마와 학교 스키마를 작성하고 학교 페이지 생성 API를 구현하였습니다
- 데이터 모델을 수정하였습니다

## Changes
<br>

![image](https://github.com/Sungyoun-Kim/news-feed/assets/58387861/a13818cd-71b7-459a-ba43-8f7543058d48)
수정된 데이터 모델입니다