### PR TITLE
14 권한 검사 가드 구현

### DIFF
--- a/src/auth/guard/role.guard.ts
+++ b/src/auth/guard/role.guard.ts
@@ -1,0 +1,37 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  SetMetadata,
+} from '@nestjs/common';
+
+import { Reflector } from '@nestjs/core';
+import { Role } from 'src/users/schema/users.schema';
+
+export const RoleLevel = (roleLevel: Role) =>
+  SetMetadata('roleLevel', roleLevel);
+
+@Injectable()
+export class RoleGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const allowUnauthorizedRequest = this.reflector.get<boolean>(
+      'allowUnauthorizedRequest',
+      context.getHandler(),
+    );
+
+    if (allowUnauthorizedRequest) {
+      return true;
+    }
+    // API에 설정된 roleLevel 가져오기
+    const roleLevel = this.reflector.get<Role>(
+      'roleLevel',
+      context.getHandler(),
+    );
+    const req: Express.Request = context.switchToHttp().getRequest();
+    const { user } = req;
+
+    return user.role >= roleLevel;
+  }
+}

--- a/src/auth/guard/role.guard.ts
+++ b/src/auth/guard/role.guard.ts
@@ -1,6 +1,7 @@
 import {
   CanActivate,
   ExecutionContext,
+  ForbiddenException,
   Injectable,
   SetMetadata,
 } from '@nestjs/common';
@@ -32,6 +33,10 @@ export class RoleGuard implements CanActivate {
     const req: Express.Request = context.switchToHttp().getRequest();
     const { user } = req;
 
-    return user.role >= roleLevel;
+    if (user.role >= roleLevel) {
+      return true;
+    } else {
+      throw new ForbiddenException('insufficient permission');
+    }
   }
 }

--- a/src/schools/schools.controller.ts
+++ b/src/schools/schools.controller.ts
@@ -10,6 +10,7 @@ import {
   Post,
   Req,
   Res,
+  UseGuards,
 } from '@nestjs/common';
 import { SchoolsService } from './schools.service';
 import { CreateSchoolPageDto } from './dto/schools.dto';
@@ -26,6 +27,8 @@ import {
   ApiTags,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
+import { RoleGuard, RoleLevel } from '../auth/guard/role.guard';
+import { Role } from '../users/schema/users.schema';
 
 @ApiTags('School')
 @Controller('schools')
@@ -51,6 +54,11 @@ export class SchoolsController {
     description:
       '- 지역이 존재하지 않는 경우\n' + '- 올바르지 못한 값이 전달된 경우',
   })
+  @ApiForbiddenResponse({
+    description: '- 권한이 부족한 경우',
+  })
+  @RoleLevel(Role.admin)
+  @UseGuards(RoleGuard)
   @Post()
   async createSchoolPage(
     @Req() req: Request,
@@ -96,8 +104,11 @@ export class SchoolsController {
   })
   @ApiForbiddenResponse({
     description:
-      '- 피드 생성을 시도한 유저가 schoolId를 가진 학교의 관리자가 아닌 경우\n',
+      '- 피드 생성을 시도한 유저가 schoolId를 가진 학교의 관리자가 아닌 경우\n' +
+      '- 권한이 부족한 경우',
   })
+  @RoleLevel(Role.admin)
+  @UseGuards(RoleGuard)
   @Post(':schoolId/feeds')
   async createSchoolFeed(
     @Req() req: Request,
@@ -147,8 +158,11 @@ export class SchoolsController {
   })
   @ApiForbiddenResponse({
     description:
-      '- 피드 삭제를 시도한 유저가 schoolId를 가진 학교의 관리자가 아닌 경우\n',
+      '- 피드 삭제를 시도한 유저가 schoolId를 가진 학교의 관리자가 아닌 경우\n' +
+      '- 권한이 부족한 경우',
   })
+  @RoleLevel(Role.admin)
+  @UseGuards(RoleGuard)
   @Delete(':schoolId/feeds/:feedId')
   async deleteSchoolFeed(
     @Req() req: Request,
@@ -208,8 +222,11 @@ export class SchoolsController {
   })
   @ApiForbiddenResponse({
     description:
-      '- 피드 수정을 시도한 유저가 schoolId를 가진 학교의 관리자가 아닌 경우\n',
+      '- 피드 수정을 시도한 유저가 schoolId를 가진 학교의 관리자가 아닌 경우\n' +
+      '- 권한이 부족한 경우',
   })
+  @RoleLevel(Role.admin)
+  @UseGuards(RoleGuard)
   @Patch(':schoolId/feeds/:feedId')
   async updateSchoolFeed(
     @Req() req: Request,

--- a/test/school.e2e-spec.ts
+++ b/test/school.e2e-spec.ts
@@ -68,6 +68,11 @@ describe('school (e2e)', () => {
       .post('/auth/login')
       .send({ email: 'suj9730@naver.com', password: '1234' });
 
+  const getUserAuth = async () =>
+    await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'student@email.com', password: '1234' });
+
   describe('/ (POST)', () => {
     it('성공적으로 학교 페이지를 생성하는 경우', async () => {
       jest.spyOn(mockRegionModel, 'query').mockImplementationOnce(() => ({
@@ -118,6 +123,22 @@ describe('school (e2e)', () => {
           statusCode: 400,
           message: 'region does not exist',
           error: 'Bad Request',
+        });
+    });
+
+    it('유저의 권한이 부족한 경우 ', async () => {
+      const response = await getUserAuth();
+      const { header } = response;
+
+      return request(app.getHttpServer())
+        .delete('/schools/uuid/feeds/uuid2')
+        .set('Accept', 'application/json')
+        .set('Cookie', [...header['set-cookie']])
+        .expect(403)
+        .expect({
+          message: 'insufficient permission',
+          error: 'Forbidden',
+          statusCode: 403,
         });
     });
   });
@@ -208,6 +229,22 @@ describe('school (e2e)', () => {
           statusCode: 403,
           message: 'no permission',
           error: 'Forbidden',
+        });
+    });
+
+    it('유저의 권한이 부족한 경우 ', async () => {
+      const response = await getUserAuth();
+      const { header } = response;
+
+      return request(app.getHttpServer())
+        .delete('/schools/uuid/feeds/uuid2')
+        .set('Accept', 'application/json')
+        .set('Cookie', [...header['set-cookie']])
+        .expect(403)
+        .expect({
+          message: 'insufficient permission',
+          error: 'Forbidden',
+          statusCode: 403,
         });
     });
   });
@@ -339,6 +376,22 @@ describe('school (e2e)', () => {
           error: 'Bad Request',
         });
     });
+
+    it('유저의 권한이 부족한 경우 ', async () => {
+      const response = await getUserAuth();
+      const { header } = response;
+
+      return request(app.getHttpServer())
+        .delete('/schools/uuid/feeds/uuid2')
+        .set('Accept', 'application/json')
+        .set('Cookie', [...header['set-cookie']])
+        .expect(403)
+        .expect({
+          message: 'insufficient permission',
+          error: 'Forbidden',
+          statusCode: 403,
+        });
+    });
   });
 
   describe('/schools/:schoolId/feeds/:feedId (PATCH)', () => {
@@ -466,6 +519,21 @@ describe('school (e2e)', () => {
           statusCode: 400,
           message: 'feed does not exist',
           error: 'Bad Request',
+        });
+    });
+    it('유저의 권한이 부족한 경우 ', async () => {
+      const response = await getUserAuth();
+      const { header } = response;
+
+      return request(app.getHttpServer())
+        .delete('/schools/uuid/feeds/uuid2')
+        .set('Accept', 'application/json')
+        .set('Cookie', [...header['set-cookie']])
+        .expect(403)
+        .expect({
+          message: 'insufficient permission',
+          error: 'Forbidden',
+          statusCode: 403,
         });
     });
   });


### PR DESCRIPTION
## Description
<br>

- 컨트롤러 별로 설정된 역할의 권한보다 낮으면 403 에러를 발생시키도록 하였습니다
- 권한은 초반 설계 때  슈퍼어드민 : 300, 어드민 : 200 , 유저 : 100 으로 설정하였었는데, 역할 이름이나 권한 유형 등은 수정 예정입니다.

## Changes
<br>

- 권한 검사가 필요한 컨트롤러에 가드를 붙임에 따라, e2e test 수정과 스웨거 수정하였습니다.