### PR TITLE
15 학생이 학교 페이지 구독 api 구현 및 e2e 코드 작성

### DIFF
--- a/src/schools/schools.controller.ts
+++ b/src/schools/schools.controller.ts
@@ -30,7 +30,7 @@ import {
 } from '@nestjs/swagger';
 import { RoleGuard, RoleLevel } from '../auth/guard/role.guard';
 import { Role } from '../users/schema/users.schema';
-import { UsersService } from 'src/users/users.service';
+import { UsersService } from '../users/users.service';
 
 @ApiTags('School')
 @Controller('schools')
@@ -273,7 +273,7 @@ export class SchoolsController {
     required: true,
   })
   @ApiCreatedResponse({
-    description: '- 학교 페이지 내에 피드 수정 성공 ',
+    description: '- 학교 페이지 구독 성공 ',
   })
   @ApiBadRequestResponse({
     description:
@@ -304,8 +304,8 @@ export class SchoolsController {
     }
 
     const result = await this.userService.subscribeSchoolPage(
-      req.user.id,
-      req.user.email,
+      user[0].id,
+      user[0].email,
       schoolId,
     );
 

--- a/src/schools/schools.module.ts
+++ b/src/schools/schools.module.ts
@@ -5,7 +5,7 @@ import { SchoolSchema } from './schema/schools.schema';
 import { DynamooseModule } from 'nestjs-dynamoose';
 import { RegionSchema } from './schema/regions.schema';
 import { FeedSchema } from './schema/feeds.schema';
-import { UsersModule } from 'src/users/users.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [

--- a/src/schools/schools.module.ts
+++ b/src/schools/schools.module.ts
@@ -5,9 +5,11 @@ import { SchoolSchema } from './schema/schools.schema';
 import { DynamooseModule } from 'nestjs-dynamoose';
 import { RegionSchema } from './schema/regions.schema';
 import { FeedSchema } from './schema/feeds.schema';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
   imports: [
+    UsersModule,
     DynamooseModule.forFeature([
       {
         name: 'Schools',

--- a/src/users/interface/user.interface.ts
+++ b/src/users/interface/user.interface.ts
@@ -1,9 +1,9 @@
 export interface UserKey {
-  id?: string;
+  id: string;
+  email: string;
 }
 
 export interface User extends UserKey {
-  email?: string;
   password: string;
   role: number;
   subscribe_schools?: string[];

--- a/src/users/schema/users.schema.ts
+++ b/src/users/schema/users.schema.ts
@@ -26,8 +26,10 @@ export const UserSchema = new Schema({
     required: true,
   },
   subscribe_schools: {
-    type: Array<string>,
+    type: Array,
+    schema: [String],
     required: false,
+    default: [],
   },
 });
 export const UserModel = model('Users', UserSchema);

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -4,7 +4,7 @@ import {
   Injectable,
   forwardRef,
 } from '@nestjs/common';
-import { InjectModel, Model } from 'nestjs-dynamoose';
+import { InjectModel, Item, Model } from 'nestjs-dynamoose';
 import { User, UserKey } from './interface/user.interface';
 import { SignUpUserDto } from './dto/users.dto';
 import { v4 } from 'uuid';
@@ -52,6 +52,18 @@ export class UsersService {
       const result = await this.userModel.query('id').eq(id).exec();
 
       return result;
+    } catch (e) {
+      console.error('쿼리를 시도하던 중 에러가 발생했습니다');
+      throw e;
+    }
+  }
+
+  async subscribeSchoolPage(userId: string, email: string, schoolId: string) {
+    try {
+      await this.userModel.update(
+        { id: userId, email: email },
+        { $ADD: { subscribe_schools: [schoolId] } },
+      );
     } catch (e) {
       console.error('쿼리를 시도하던 중 에러가 발생했습니다');
       throw e;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -60,10 +60,12 @@ export class UsersService {
 
   async subscribeSchoolPage(userId: string, email: string, schoolId: string) {
     try {
-      await this.userModel.update(
+      const result = await this.userModel.update(
         { id: userId, email: email },
         { $ADD: { subscribe_schools: [schoolId] } },
       );
+      const { password, ...rest } = result;
+      return rest;
     } catch (e) {
       console.error('쿼리를 시도하던 중 에러가 발생했습니다');
       throw e;


### PR DESCRIPTION
## Description
<br>

- 학생이 학교 페이지 구독하는 API 구현하였습니다 
- 학교 탐색 -> 유저 탐색 -> 구독하고 있는지 확인 후 구독하도록 구현했습니다
- mongoose 처럼 .save()가 지원되지 않아 update 문 사용하였습니다
- 구현한 API에 대하여 e2e 테스트 코드 작성하였습니다

## Changes
<br>

- 오타나 실수들 수정하였습니다
