### PR TITLE
17 학생이 구독 중인 학교 페이지 구독 취소 api 구현 및 e2e 코드 작성

### DIFF
--- a/src/schools/schools.controller.ts
+++ b/src/schools/schools.controller.ts
@@ -348,4 +348,52 @@ export class SchoolsController {
       res.status(HttpStatus.OK).json(result);
     }
   }
+
+  @ApiOperation({
+    summary: '유저가 학교 페이지를 구독 취소',
+    description: '- 학생은 학교 페이지를 구독을 취소할 수 있다\n',
+  })
+  @ApiParam({
+    name: 'schoolId',
+    description: '구독을 취소하려는 학교의 id',
+    required: true,
+  })
+  @ApiCreatedResponse({
+    description: '- 학교 페이지 구독 취소 성공 ',
+  })
+  @ApiBadRequestResponse({
+    description:
+      '- schoolId를 가진 학교가 존재하지 않는 경우 \n' +
+      '- 유저가 이미 schoolId를 가진 학교 페이지를 구독한 상태가 아닌 경우 \n' +
+      '- 올바르지 못한 값이 전달된 경우',
+  })
+  @ApiUnauthorizedResponse({
+    description: '- 요청이 인가되지 않은 경우',
+  })
+  @RoleLevel(Role.user)
+  @UseGuards(RoleGuard)
+  @Patch(':schoolId/unsubscribe')
+  async unsubscribeSchoolPage(
+    @Req() req: Request,
+    @Param('schoolId') schoolId: string,
+    @Res() res: Response,
+  ) {
+    const school = await this.schoolService.findSchoolById(schoolId);
+    if (!school[0]) {
+      throw new BadRequestException('schoold does not exist');
+    }
+
+    const user = await this.userService.findUserById(req.user.id);
+
+    if (user[0] && !user[0].subscribe_schools.includes(schoolId)) {
+      throw new BadRequestException('user already unsubscribe school');
+    }
+
+    const result = await this.userService.unsubscribeSchoolPage(
+      user[0],
+      schoolId,
+    );
+
+    res.status(201).json(result);
+  }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -71,4 +71,26 @@ export class UsersService {
       throw e;
     }
   }
+
+  /*
+   *https://github.com/dynamoose/dynamoose/issues/398
+   *$ADD가 set이나 list에 요소를 추가하는 것 처럼
+   *요소를 제거하는 것이 지원되지 않는 것 같습니다
+   */
+  async unsubscribeSchoolPage(user: User, schoolId: string) {
+    try {
+      const deletedSchoolArr = user.subscribe_schools.filter(
+        (id) => id !== schoolId,
+      );
+      const result = await this.userModel.update(
+        { id: user.id, email: user.email },
+        { $SET: { subscribe_schools: deletedSchoolArr } },
+      );
+      const { password, ...rest } = result;
+      return rest;
+    } catch (e) {
+      console.error('쿼리를 시도하던 중 에러가 발생했습니다');
+      throw e;
+    }
+  }
 }


### PR DESCRIPTION
## Description
<br>

- 학생이 학교 페이지 구독을 취소하는 API 구현하였습니다
- 학교 유무 확인 -> 유저의 구독 유무 확인 - > 구독 취소 합니다.
- e2e 테스트 작성했습니다

구독 시  $ADD를 이용해 list 에 접근해 요소를 추가하였던 것 처럼
구독 취소 시 $DELETE를 이용해 list를 접근하여 요소를 제거하려하였으나 모든 요소가 제거되는 문제 있었습니다
(https://github.com/dynamoose/dynamoose/issues/398 )
그래서 유저로부터 구독중인 학교 리스트를 받아 직접 제거한 후 $SET 해주었습니다

## Changes
<br>

