### PR TITLE
32 학생은 구독중인 학교 소식을 자신의 뉴스피드에서 모아보기 api 구현

### DIFF
--- a/src/feeds/feeds.controller.ts
+++ b/src/feeds/feeds.controller.ts
@@ -37,6 +37,7 @@ import { Request, Response } from 'express';
 import { FeedsService } from './feeds.service';
 import { SchoolsService } from '../schools/schools.service';
 import { UsersService } from '../users/users.service';
+import { Feed } from './interface/feeds.interface';
 
 @ApiTags('Feed')
 @Controller()
@@ -305,7 +306,8 @@ export class FeedsController {
       req.user.id,
       req.user.email,
     );
-    let userFeed = [];
+    let userFeed: Feed[] = [];
+
     const subscribeFeed = await this.feedService.findSubscribeFeed(
       user.subscribe_schools,
     );

--- a/src/feeds/feeds.controller.ts
+++ b/src/feeds/feeds.controller.ts
@@ -271,7 +271,10 @@ export class FeedsController {
       req.user.email,
     );
 
-    if (user && !user.subscribe_schools.includes(schoolId)) {
+    if (
+      user &&
+      !user.subscribe_schools.find((school) => school.id == schoolId)
+    ) {
       throw new ForbiddenException('should subscribe school page');
     }
     const result = await this.feedService.findSchoolFeeds(schoolId);

--- a/src/feeds/feeds.module.ts
+++ b/src/feeds/feeds.module.ts
@@ -5,6 +5,7 @@ import { DynamooseModule } from 'nestjs-dynamoose';
 import { FeedSchema } from './schema/feeds.schema';
 import { UsersModule } from '../users/users.module';
 import { SchoolsModule } from '../schools/schools.module';
+import { UnsubscribedFeedSchema } from './schema/unsubscribed-feeds.schema';
 
 @Module({
   imports: [
@@ -16,6 +17,13 @@ import { SchoolsModule } from '../schools/schools.module';
         schema: FeedSchema,
         options: {
           tableName: 'feeds',
+        },
+      },
+      {
+        name: 'UnsubscribedFeeds',
+        schema: UnsubscribedFeedSchema,
+        options: {
+          tableName: 'unsubscribed-feeds',
         },
       },
     ]),

--- a/src/feeds/interface/unsubscribed-feeds.interface.ts
+++ b/src/feeds/interface/unsubscribed-feeds.interface.ts
@@ -1,8 +1,10 @@
+import { Feed } from './feeds.interface';
+
 export interface UnsubscribedFeedKey {
   user_id: string;
 }
 
 export interface UnsubscribedFeed extends UnsubscribedFeedKey {
-  feeds: object[];
+  feeds: Feed[];
   created_at?: number;
 }

--- a/src/feeds/interface/unsubscribed-feeds.interface.ts
+++ b/src/feeds/interface/unsubscribed-feeds.interface.ts
@@ -1,0 +1,8 @@
+export interface UnsubscribedFeedKey {
+  user_id: string;
+}
+
+export interface UnsubscribedFeed extends UnsubscribedFeedKey {
+  feeds: object[];
+  created_at?: number;
+}

--- a/src/feeds/schema/unsubscribed-feeds.schema.ts
+++ b/src/feeds/schema/unsubscribed-feeds.schema.ts
@@ -1,0 +1,34 @@
+import { Schema, model } from 'dynamoose';
+import { SchoolModel } from '../../schools/schema/schools.schema';
+import { v4 } from 'uuid';
+import { FeedModel } from './feeds.schema';
+
+export const UnsubscribedFeedSchema = new Schema({
+  user_id: {
+    type: String,
+    required: true,
+    hashKey: true,
+  },
+  feeds: {
+    type: Array,
+    schema: [
+      {
+        type: Object,
+        schema: {
+          id: {
+            type: String,
+          },
+          created_at: { type: Number },
+          school: { type: Object, schema: { name: String, id: String } },
+          content: { type: String },
+          subject: { type: String },
+        },
+      },
+    ],
+  },
+  created_at: {
+    type: Date,
+    default: () => Date.now(),
+    rangeKey: true,
+  },
+});

--- a/src/schools/schools.controller.ts
+++ b/src/schools/schools.controller.ts
@@ -128,7 +128,10 @@ export class SchoolsController {
       req.user.email,
     );
 
-    if (user && user.subscribe_schools.includes(schoolId)) {
+    if (
+      user &&
+      user.subscribe_schools.find((school) => school.id == schoolId)
+    ) {
       throw new BadRequestException('user already subscribe school');
     }
 
@@ -169,9 +172,11 @@ export class SchoolsController {
     if (user.subscribe_schools.length == 0) {
       res.status(HttpStatus.OK).json([]);
     } else {
+      const subscribeSchoolIds = [];
+      user.subscribe_schools.map((school) => subscribeSchoolIds.push(school));
       const result = await this.schoolService.findSubscribeSchoolPages(
-        user.subscribe_schools,
-      );
+        subscribeSchoolIds,
+      );subscribeSchoolIds
       res.status(HttpStatus.OK).json(result);
     }
   }
@@ -215,7 +220,10 @@ export class SchoolsController {
       req.user.email,
     );
 
-    if (user && !user.subscribe_schools.includes(school.id)) {
+    if (
+      user &&
+      !user.subscribe_schools.find((school) => school.id == schoolId)
+    ) {
       throw new BadRequestException('user already unsubscribe school');
     }
 

--- a/src/schools/schools.controller.ts
+++ b/src/schools/schools.controller.ts
@@ -176,14 +176,17 @@ export class SchoolsController {
       user.subscribe_schools.map((school) => subscribeSchoolIds.push(school));
       const result = await this.schoolService.findSubscribeSchoolPages(
         subscribeSchoolIds,
-      );subscribeSchoolIds
+      );
+
       res.status(HttpStatus.OK).json(result);
     }
   }
 
   @ApiOperation({
     summary: '학생이 학교 페이지를 구독 취소',
-    description: '- 학생은 학교 페이지를 구독을 취소할 수 있다\n',
+    description:
+      '- 학생은 학교 페이지를 구독을 취소할 수 있다\n' +
+      '- 구독을 취소할 시 구독 시점부터 취소 시점까지의 소식을 다른 테이블에 저장합니다.\n',
   })
   @ApiParam({
     name: 'schoolId',
@@ -227,11 +230,12 @@ export class SchoolsController {
       throw new BadRequestException('user already unsubscribe school');
     }
 
-    const result = await this.userService.unsubscribeSchoolPage(
-      user,
-      school.id,
-    );
+    await this.userService.unsubscribeSchoolPage(user, school.id);
 
+    const result = await this.userService.findUserByIdAndEmail(
+      user.id,
+      user.email,
+    );
     res.status(201).json(result);
   }
 }

--- a/src/schools/schools.module.ts
+++ b/src/schools/schools.module.ts
@@ -4,7 +4,7 @@ import { SchoolsController } from './schools.controller';
 import { SchoolSchema } from './schema/schools.schema';
 import { DynamooseModule } from 'nestjs-dynamoose';
 import { RegionSchema } from './schema/regions.schema';
-import { FeedSchema } from '../feeds/schema/feeds.schema';
+
 import { UsersModule } from '../users/users.module';
 
 @Module({

--- a/src/schools/schools.service.ts
+++ b/src/schools/schools.service.ts
@@ -4,8 +4,6 @@ import { School, SchoolKey } from './interface/schools.interface';
 import { Region, RegionKey } from './interface/regions.interface';
 import { CreateSchoolPageDto } from './dto/schools.dto';
 
-import { Feed, FeedKey } from '../feeds/interface/feeds.interface';
-
 @Injectable()
 export class SchoolsService {
   constructor(

--- a/src/users/interface/user.interface.ts
+++ b/src/users/interface/user.interface.ts
@@ -6,5 +6,5 @@ export interface UserKey {
 export interface User extends UserKey {
   password: string;
   role: number;
-  subscribe_schools?: string[];
+  subscribe_schools?: { id: string; subscribe_at: number }[];
 }

--- a/src/users/schema/users.schema.ts
+++ b/src/users/schema/users.schema.ts
@@ -28,7 +28,7 @@ export const UserSchema = new Schema({
   },
   subscribe_schools: {
     type: Array,
-    schema: [String],
+    schema: [{ type: Object, schema: { id: String, subscribe_at: Number } }],
     required: false,
     default: [],
   },

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -5,7 +5,7 @@ import { UserSchema } from './schema/users.schema';
 import { DynamooseModule } from 'nestjs-dynamoose';
 import { AuthModule } from '../auth/auth.module';
 import { FeedSchema } from '../feeds/schema/feeds.schema';
-import { UnsubscribedFeedSchema } from 'src/feeds/schema/unsubscribed-feeds.schema';
+import { UnsubscribedFeedSchema } from '../feeds/schema/unsubscribed-feeds.schema';
 
 @Module({
   imports: [

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -4,11 +4,27 @@ import { UsersController } from './users.controller';
 import { UserSchema } from './schema/users.schema';
 import { DynamooseModule } from 'nestjs-dynamoose';
 import { AuthModule } from '../auth/auth.module';
+import { FeedSchema } from '../feeds/schema/feeds.schema';
+import { UnsubscribedFeedSchema } from 'src/feeds/schema/unsubscribed-feeds.schema';
 
 @Module({
   imports: [
     forwardRef(() => AuthModule),
     DynamooseModule.forFeature([
+      {
+        name: 'Feeds',
+        schema: FeedSchema,
+        options: {
+          tableName: 'feeds',
+        },
+      },
+      {
+        name: 'UnsubscribedFeeds',
+        schema: UnsubscribedFeedSchema,
+        options: {
+          tableName: 'unsubscribed-feeds',
+        },
+      },
       {
         name: 'Users',
         schema: UserSchema,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -4,19 +4,32 @@ import {
   Injectable,
   forwardRef,
 } from '@nestjs/common';
-import { InjectModel, Item, Model } from 'nestjs-dynamoose';
+import { InjectModel, Model, TransactionSupport } from 'nestjs-dynamoose';
 import { User, UserKey } from './interface/user.interface';
 import { SignUpUserDto } from './dto/users.dto';
-import { v4 } from 'uuid';
 import { AuthService } from '../auth/auth.service';
+import { Feed, FeedKey } from 'src/feeds/interface/feeds.interface';
+import {
+  UnsubscribedFeed,
+  UnsubscribedFeedKey,
+} from 'src/feeds/interface/unsubscribed-feeds.interface';
 @Injectable()
-export class UsersService {
+export class UsersService extends TransactionSupport {
   constructor(
     @InjectModel('Users')
-    private userModel: Model<User, UserKey>,
+    private readonly userModel: Model<User, UserKey>,
+    @InjectModel('Feeds')
+    private readonly feedModel: Model<Feed, FeedKey>,
+    @InjectModel('UnsubscribedFeeds')
+    private readonly unsubscribedFeedModel: Model<
+      UnsubscribedFeed,
+      UnsubscribedFeedKey
+    >,
     @Inject(forwardRef(() => AuthService))
     private readonly authService: AuthService,
-  ) {}
+  ) {
+    super();
+  }
 
   async signUpUser(signUpUserDto: SignUpUserDto) {
     signUpUserDto.password = await this.authService.hashPassword(
@@ -85,12 +98,33 @@ export class UsersService {
       const deletedSchoolArr = user.subscribe_schools.filter(
         (school) => school.id !== schoolId,
       );
-      const result = await this.userModel.update(
-        { id: user.id, email: user.email },
-        { $SET: { subscribe_schools: deletedSchoolArr } },
+      const unscribeSchoolInfo = user.subscribe_schools.find(
+        (school) => school.id == schoolId,
       );
-      const { password, ...rest } = result;
-      return rest;
+
+      const unsubscribedFeeds = await this.feedModel
+        .scan('school.id')
+        .eq(schoolId)
+        .where('created_at')
+        .between(unscribeSchoolInfo.subscribe_at, Date.now())
+        .exec();
+
+      unsubscribedFeeds.map((feed) => {
+        feed.created_at = feed.created_at.valueOf();
+        return feed;
+      });
+
+      await this.transaction([
+        this.unsubscribedFeedModel.transaction.create({
+          user_id: user.id,
+          feeds: JSON.parse(JSON.stringify(unsubscribedFeeds)),
+        }),
+
+        this.userModel.transaction.update(
+          { id: user.id, email: user.email },
+          { $SET: { subscribe_schools: deletedSchoolArr } },
+        ),
+      ]);
     } catch (e) {
       console.error('쿼리를 시도하던 중 에러가 발생했습니다');
       throw e;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -61,7 +61,11 @@ export class UsersService {
     try {
       const result = await this.userModel.update(
         { id: userId, email: email },
-        { $ADD: { subscribe_schools: [schoolId] } },
+        {
+          $ADD: {
+            subscribe_schools: [{ id: schoolId, subscribe_at: Date.now() }],
+          },
+        },
       );
       const { password, ...rest } = result;
       return rest;
@@ -79,7 +83,7 @@ export class UsersService {
   async unsubscribeSchoolPage(user: User, schoolId: string) {
     try {
       const deletedSchoolArr = user.subscribe_schools.filter(
-        (id) => id !== schoolId,
+        (school) => school.id !== schoolId,
       );
       const result = await this.userModel.update(
         { id: user.id, email: user.email },

--- a/test/feed.e2e-spec.ts
+++ b/test/feed.e2e-spec.ts
@@ -60,7 +60,7 @@ describe('school (e2e)', () => {
   const getInvalidAdminAuth = async () =>
     await request(app.getHttpServer())
       .post('/auth/login')
-      .send({ email: 'suj9730@naver.com', password: '1234' });
+      .send({ email: 'invalidAdmin@email.com', password: '1234' });
 
   const getUserAuth = async () =>
     await request(app.getHttpServer())
@@ -70,7 +70,7 @@ describe('school (e2e)', () => {
   const getAdminAuth = async () =>
     await request(app.getHttpServer())
       .post('/auth/login')
-      .send({ email: 'suj970@naver.com', password: '1234' });
+      .send({ email: 'admin@email.com', password: '1234' });
 
   describe('/schools/:id/feed (POST)', () => {
     it('성공적으로 피드를 작성하는 경우', async () => {
@@ -78,7 +78,7 @@ describe('school (e2e)', () => {
         region_name: '경상남도',
         id: 'uuid',
         name: '행복고등학교',
-        admins: ['b7cba70b-78bc-438e-b08b-0679282c15a0'],
+        admins: ['90011720-73f2-454e-bce1-0f0fadf02dc5'],
       }));
 
       jest.spyOn(mockFeedModel, 'create').mockImplementationOnce(() => ({
@@ -186,7 +186,7 @@ describe('school (e2e)', () => {
         region_name: '경상남도',
         id: 'uuid',
         name: '행복고등학교',
-        admins: ['b7cba70b-78bc-438e-b08b-0679282c15a0'],
+        admins: ['90011720-73f2-454e-bce1-0f0fadf02dc5'],
       }));
 
       jest.spyOn(mockFeedModel, 'query').mockImplementationOnce(() => ({
@@ -260,7 +260,7 @@ describe('school (e2e)', () => {
         region_name: '경상남도',
         id: 'uuid',
         name: '행복고등학교',
-        admins: ['b7cba70b-78bc-438e-b08b-0679282c15a0'],
+        admins: ['90011720-73f2-454e-bce1-0f0fadf02dc5'],
       }));
 
       jest.spyOn(mockFeedModel, 'query').mockImplementationOnce(() => ({
@@ -307,7 +307,7 @@ describe('school (e2e)', () => {
         region_name: '경상남도',
         id: 'uuid',
         name: '행복고등학교',
-        admins: ['b7cba70b-78bc-438e-b08b-0679282c15a0'],
+        admins: ['90011720-73f2-454e-bce1-0f0fadf02dc5'],
       }));
 
       jest.spyOn(mockFeedModel, 'query').mockImplementationOnce(() => ({
@@ -381,7 +381,7 @@ describe('school (e2e)', () => {
         region_name: '경상남도',
         id: 'uuid',
         name: '행복고등학교',
-        admins: ['b7cba70b-78bc-438e-b08b-0679282c15a0'],
+        admins: ['90011720-73f2-454e-bce1-0f0fadf02dc5'],
       }));
 
       jest.spyOn(mockFeedModel, 'query').mockImplementationOnce(() => ({
@@ -436,7 +436,7 @@ describe('school (e2e)', () => {
           email: 'test1234@naver.com',
           id: 'uuid',
           role: 200,
-          subscribe_schools: ['uuid'],
+          subscribe_schools: [{ id: 'uuid', subscribe_at: 12345678 }],
         } as Item<User>);
 
       jest.spyOn(mockFeedModel, 'scan').mockImplementationOnce(() => ({

--- a/test/school.e2e-spec.ts
+++ b/test/school.e2e-spec.ts
@@ -67,7 +67,7 @@ describe('school (e2e)', () => {
   const getAdminAuth = async () =>
     await request(app.getHttpServer())
       .post('/auth/login')
-      .send({ email: 'suj970@naver.com', password: '1234' });
+      .send({ email: 'admin@email.com', password: '1234' });
 
   const getUserAuth = async () =>
     await request(app.getHttpServer())
@@ -159,15 +159,16 @@ describe('school (e2e)', () => {
           email: 'test1234@naver.com',
           id: 'uuid',
           role: 200,
-          subscribe_schools: ['82d9823c-6f22-4c33-9f8c-f1c5ffce171b'],
+          subscribe_schools: [],
         } as Item<User>);
+
       jest
         .spyOn(UsersService.prototype, 'subscribeSchoolPage')
         .mockResolvedValue({
           email: 'test1234@naver.com',
           id: 'uuid',
           role: 200,
-          subscribe_schools: ['82d9823c-6f22-4c33-9f8c-f1c5ffce171b', 'uuid'],
+          subscribe_schools: [{ id: 'uuid', subscribe_at: 12345678 }],
         } as Omit<Item<User>, 'password'>);
 
       const response = await getUserAuth();
@@ -182,7 +183,7 @@ describe('school (e2e)', () => {
           email: 'test1234@naver.com',
           id: 'uuid',
           role: 200,
-          subscribe_schools: ['82d9823c-6f22-4c33-9f8c-f1c5ffce171b', 'uuid'],
+          subscribe_schools: [{ id: 'uuid', subscribe_at: 12345678 }],
         });
     });
 
@@ -214,7 +215,7 @@ describe('school (e2e)', () => {
             email: 'test1234@naver.com',
             id: 'uuid',
             role: 200,
-            subscribe_schools: ['82d9823c-6f22-4c33-9f8c-f1c5ffce171b', 'uuid'],
+            subscribe_schools: [{ id: 'uuid', subscribe_at: 12345678 }],
           } as Item<User>);
 
       const response = await getUserAuth();
@@ -241,7 +242,7 @@ describe('school (e2e)', () => {
           email: 'test1234@naver.com',
           id: 'uuid',
           role: 200,
-          subscribe_schools: ['82d9823c-6f22-4c33-9f8c-f1c5ffce171b'],
+          subscribe_schools: [{ id: 'uuid', subscribe_at: 12345678 }],
         } as Item<User>);
 
       jest.spyOn(mockSchoolModel, 'scan').mockImplementationOnce(() => ({
@@ -290,16 +291,12 @@ describe('school (e2e)', () => {
           email: 'test1234@naver.com',
           id: 'uuid',
           role: 200,
-          subscribe_schools: ['uuid'],
+          subscribe_schools: [{ id: 'uuid', subscribe_at: 12345678 }],
         } as Item<User>);
+
       jest
         .spyOn(UsersService.prototype, 'unsubscribeSchoolPage')
-        .mockResolvedValue({
-          email: 'test1234@naver.com',
-          id: 'uuid',
-          role: 200,
-          subscribe_schools: [],
-        } as Omit<Item<User>, 'password'>);
+        .mockResolvedValue();
 
       const response = await getUserAuth();
       const { header } = response;
@@ -313,7 +310,7 @@ describe('school (e2e)', () => {
           email: 'test1234@naver.com',
           id: 'uuid',
           role: 200,
-          subscribe_schools: [],
+          subscribe_schools: [{ id: 'uuid', subscribe_at: 12345678 }],
         });
     });
 

--- a/test/school.e2e-spec.ts
+++ b/test/school.e2e-spec.ts
@@ -144,7 +144,7 @@ describe('school (e2e)', () => {
     });
   });
 
-  describe('/schools/:schoolId/subscribe', () => {
+  describe('/schools/:schoolId/subscribe (PATCH)', () => {
     it('유저가 성공적으로 구독하는 경우', async () => {
       jest.spyOn(mockSchoolModel, 'get').mockImplementationOnce(() => ({
         region_name: '경상남도',
@@ -234,7 +234,7 @@ describe('school (e2e)', () => {
     });
   });
 
-  describe('/schools/subscribe', () => {
+  describe('/schools/subscribe (GET)', () => {
     it('유저가 성공적으로 구독하는 학교 페이지 목록을 조회하는 경우', async () => {
       jest
         .spyOn(UsersService.prototype, 'findUserByIdAndEmail')
@@ -276,7 +276,7 @@ describe('school (e2e)', () => {
     });
   });
 
-  describe('/schools/:schoolId/unsubscribe', () => {
+  describe('/schools/:schoolId/unsubscribe (PATCH)', () => {
     it('유저가 성공적으로 구독을 취소하는 경우', async () => {
       jest.spyOn(mockSchoolModel, 'get').mockImplementationOnce(() => ({
         region_name: '경상남도',


### PR DESCRIPTION
## Description
<br>

- 구독중인 소식을 뉴스피드에서 모아보기 API 구현했습니다
- 구독한 시점 이후 소식부터 받기 위해 유저의 스키마를 수정했습니다
- 구독을 취소해도 기존에 나타났던 소식을 유지하기 위해 unsubsribedFeed 테이블을 만들어 구독 취소한 소식들을 저장했다가 API호출시 가지고 옵니다
- 구독을 취소하는 API의 로직이 수정되었습니다

## Changes
<br>

![image](https://github.com/Sungyoun-Kim/news-feed/assets/58387861/08bf6c85-2a70-4520-b2ce-a28f6f1a96d5)
최종 DB 입니다


